### PR TITLE
Traceton/postresql fix

### DIFF
--- a/commands/generate/pages/pageTypeNonePages/generateCreate.js
+++ b/commands/generate/pages/pageTypeNonePages/generateCreate.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.generateCreate = void 0;
-const generateCreate = (modelName, upperCaseFirstLetterModelName, finalJsonBodyItems, finalFormFieldItems) => {
+const generateCreate = (modelName, idType, upperCaseFirstLetterModelName, finalJsonBodyItems, finalFormFieldItems) => {
     const createPage = `
     import { useRouter } from 'next/router'
   import React from "react";

--- a/commands/generate/pages/pageTypeNonePages/generateCreate.ts
+++ b/commands/generate/pages/pageTypeNonePages/generateCreate.ts
@@ -1,4 +1,4 @@
-export const generateCreate = (modelName: string, upperCaseFirstLetterModelName: string, finalJsonBodyItems: string, finalFormFieldItems: string) => {
+export const generateCreate = (modelName: string, idType: string, upperCaseFirstLetterModelName: string, finalJsonBodyItems: string, finalFormFieldItems: string) => {
 
     const createPage = `
     import { useRouter } from 'next/router'

--- a/commands/generate/pages/pageTypeNonePages/generateDynamic.js
+++ b/commands/generate/pages/pageTypeNonePages/generateDynamic.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.generateDynamic = void 0;
-const generateDynamic = (modelName, upperCaseFirstLetterModelName, finalSchemaItemsForDynamicPage) => {
+const generateDynamic = (modelName, idType, upperCaseFirstLetterModelName, finalSchemaItemsForDynamicPage) => {
     const dynamicPage = `
     import Link from 'next/link'
   import { useRouter } from "next/router";
@@ -29,7 +29,7 @@ const generateDynamic = (modelName, upperCaseFirstLetterModelName, finalSchemaIt
                     >
                       Back
                     </button>
-                    <Link href={"/${modelName}s/edit${upperCaseFirstLetterModelName}s/" + ${modelName}._id}>
+                    <Link href={"/${modelName}s/edit${upperCaseFirstLetterModelName}s/" + ${modelName}.${idType}}>
                       <a>
                         Edit
                       </a>

--- a/commands/generate/pages/pageTypeNonePages/generateDynamic.ts
+++ b/commands/generate/pages/pageTypeNonePages/generateDynamic.ts
@@ -1,4 +1,4 @@
-export const generateDynamic = (modelName: string, upperCaseFirstLetterModelName: string, finalSchemaItemsForDynamicPage: string) => {
+export const generateDynamic = (modelName: string, idType: string, upperCaseFirstLetterModelName: string, finalSchemaItemsForDynamicPage: string) => {
 
     const dynamicPage = `
     import Link from 'next/link'
@@ -27,7 +27,7 @@ export const generateDynamic = (modelName: string, upperCaseFirstLetterModelName
                     >
                       Back
                     </button>
-                    <Link href={"/${modelName}s/edit${upperCaseFirstLetterModelName}s/" + ${modelName}._id}>
+                    <Link href={"/${modelName}s/edit${upperCaseFirstLetterModelName}s/" + ${modelName}.${idType}}>
                       <a>
                         Edit
                       </a>

--- a/commands/generate/pages/pageTypeNonePages/generateEdit.js
+++ b/commands/generate/pages/pageTypeNonePages/generateEdit.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.generateEdit = void 0;
-const generateEdit = (modelName, upperCaseFirstLetterModelName, finalJsonBodyItems, finalEditFormFieldItems) => {
+const generateEdit = (modelName, idType, upperCaseFirstLetterModelName, finalJsonBodyItems, finalEditFormFieldItems) => {
     const editPage = `
     import { useRouter } from "next/router";
   

--- a/commands/generate/pages/pageTypeNonePages/generateEdit.ts
+++ b/commands/generate/pages/pageTypeNonePages/generateEdit.ts
@@ -1,4 +1,4 @@
-export const generateEdit = (modelName: string, upperCaseFirstLetterModelName: string, finalJsonBodyItems: string, finalEditFormFieldItems: string) => {
+export const generateEdit = (modelName: string, idType: string, upperCaseFirstLetterModelName: string, finalJsonBodyItems: string, finalEditFormFieldItems: string) => {
 
     const editPage = `
     import { useRouter } from "next/router";

--- a/commands/generate/pages/pageTypeNonePages/generateIndex.js
+++ b/commands/generate/pages/pageTypeNonePages/generateIndex.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.generateIndex = void 0;
 const pagesUtils_1 = require("./pagesUtils");
-const generateIndex = (modelName, finalSchemaItemsForIndex) => {
+const generateIndex = (modelName, idType, finalSchemaItemsForIndex) => {
     let upperCaseFirstLetterModelName = (0, pagesUtils_1.getUpperCaseFirstLetter)(modelName);
     const noneIndex = `
     import Link from 'next/link'
@@ -27,10 +27,10 @@ const generateIndex = (modelName, finalSchemaItemsForIndex) => {
               <div>
                 {props.${modelName}s.map((${modelName}) => (
                   <div
-                    key={${modelName}._id}  
+                    key={${modelName}.${idType}}  
                   >
                     <div>
-                      <a href={"/${modelName}s/" + ${modelName}._id}>
+                      <a href={"/${modelName}s/" + ${modelName}.${idType}}>
                         <span aria-hidden="true" />
                         ${finalSchemaItemsForIndex}
                       </a>

--- a/commands/generate/pages/pageTypeNonePages/generateIndex.ts
+++ b/commands/generate/pages/pageTypeNonePages/generateIndex.ts
@@ -1,7 +1,7 @@
 import { getUpperCaseFirstLetter } from "./pagesUtils"
 
 // Generate the index page.
-export const generateIndex = (modelName: string, finalSchemaItemsForIndex: string) => {
+export const generateIndex = (modelName: string, idType: string, finalSchemaItemsForIndex: string) => {
 
     let upperCaseFirstLetterModelName = getUpperCaseFirstLetter(modelName)
 
@@ -29,10 +29,10 @@ export const generateIndex = (modelName: string, finalSchemaItemsForIndex: strin
               <div>
                 {props.${modelName}s.map((${modelName}) => (
                   <div
-                    key={${modelName}._id}  
+                    key={${modelName}.${idType}}  
                   >
                     <div>
-                      <a href={"/${modelName}s/" + ${modelName}._id}>
+                      <a href={"/${modelName}s/" + ${modelName}.${idType}}>
                         <span aria-hidden="true" />
                         ${finalSchemaItemsForIndex}
                       </a>

--- a/commands/generate/pages/pageTypeNonePages/nonePageController.js
+++ b/commands/generate/pages/pageTypeNonePages/nonePageController.js
@@ -11,6 +11,7 @@ const generateEdit_1 = require("./generateEdit");
 const nonePageController = async (userInput) => {
     const modelName = userInput[2];
     let configData = (0, utils_1.readNextConfig)();
+    let idType = (0, utils_1.getIdType)();
     const modelItems = userInput.slice(3);
     if (!modelName) {
         return `no modelName recieved`;
@@ -20,10 +21,10 @@ const nonePageController = async (userInput) => {
     }
     const upperCaseFirstLetterModelName = modelName.charAt(0).toUpperCase() + modelName.slice(1);
     const finalDynamicData = (0, getDynamicNoneData_1.getDynamicNoneData)(modelName, modelItems);
-    const indexPage = (0, generateIndex_1.generateIndex)(modelName, finalDynamicData.finalSchemaItemsForIndex);
-    const dynamicPage = (0, generateDynamic_1.generateDynamic)(modelName, upperCaseFirstLetterModelName, finalDynamicData.finalSchemaItemsForDynamicPage);
-    const createPage = (0, generateCreate_1.generateCreate)(modelName, upperCaseFirstLetterModelName, finalDynamicData.finalJsonBodyItems, finalDynamicData.finalFormFieldItems);
-    const editPage = (0, generateEdit_1.generateEdit)(modelName, upperCaseFirstLetterModelName, finalDynamicData.finalJsonBodyItems, finalDynamicData.finalEditFormFieldItems);
+    const indexPage = (0, generateIndex_1.generateIndex)(modelName, idType, finalDynamicData.finalSchemaItemsForIndex);
+    const dynamicPage = (0, generateDynamic_1.generateDynamic)(modelName, idType, upperCaseFirstLetterModelName, finalDynamicData.finalSchemaItemsForDynamicPage);
+    const createPage = (0, generateCreate_1.generateCreate)(modelName, idType, upperCaseFirstLetterModelName, finalDynamicData.finalJsonBodyItems, finalDynamicData.finalFormFieldItems);
+    const editPage = (0, generateEdit_1.generateEdit)(modelName, idType, upperCaseFirstLetterModelName, finalDynamicData.finalJsonBodyItems, finalDynamicData.finalEditFormFieldItems);
     if (!(0, fs_1.existsSync)(`${configData.projectRootPath}pages`)) {
         (0, utils_1.createDirectory)(`${configData.projectRootPath}pages`);
     }

--- a/commands/generate/pages/pageTypeNonePages/nonePageController.ts
+++ b/commands/generate/pages/pageTypeNonePages/nonePageController.ts
@@ -1,5 +1,4 @@
-
-import { createDirectory, createFile, readNextConfig } from "../../../../utils";
+import { createDirectory, createFile, getIdType, readNextConfig } from "../../../../utils";
 import { existsSync } from "fs";
 import { getDynamicNoneData } from "./getDynamicNoneData"
 import { generateIndex } from "./generateIndex"
@@ -11,6 +10,7 @@ export const nonePageController = async (userInput: string[]) => {
   const modelName = userInput[2];
 
   let configData = readNextConfig()
+  let idType = getIdType()
 
   const modelItems = userInput.slice(3);
 
@@ -29,16 +29,16 @@ export const nonePageController = async (userInput: string[]) => {
   const finalDynamicData = getDynamicNoneData(modelName, modelItems)
 
   // generates the index page
-  const indexPage = generateIndex(modelName, finalDynamicData.finalSchemaItemsForIndex)
+  const indexPage = generateIndex(modelName, idType, finalDynamicData.finalSchemaItemsForIndex)
 
   //  generates the dynamic page
-  const dynamicPage = generateDynamic(modelName, upperCaseFirstLetterModelName, finalDynamicData.finalSchemaItemsForDynamicPage)
+  const dynamicPage = generateDynamic(modelName, idType, upperCaseFirstLetterModelName, finalDynamicData.finalSchemaItemsForDynamicPage)
 
   // generates the create page
-  const createPage = generateCreate(modelName, upperCaseFirstLetterModelName, finalDynamicData.finalJsonBodyItems, finalDynamicData.finalFormFieldItems)
+  const createPage = generateCreate(modelName, idType, upperCaseFirstLetterModelName, finalDynamicData.finalJsonBodyItems, finalDynamicData.finalFormFieldItems)
 
   // generates the edit page
-  const editPage = generateEdit(modelName, upperCaseFirstLetterModelName, finalDynamicData.finalJsonBodyItems, finalDynamicData.finalEditFormFieldItems)
+  const editPage = generateEdit(modelName, idType, upperCaseFirstLetterModelName, finalDynamicData.finalJsonBodyItems, finalDynamicData.finalEditFormFieldItems)
 
 
 

--- a/commands/generate/pages/pageTypeTailwindcssPages/generateCreate.js
+++ b/commands/generate/pages/pageTypeTailwindcssPages/generateCreate.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.generateCreate = void 0;
-const generateCreate = (modelName, upperCaseFirstLetterModelName, finalJsonBodyItems, finalFormFieldItems) => {
+const generateCreate = (modelName, idType, upperCaseFirstLetterModelName, finalJsonBodyItems, finalFormFieldItems) => {
     const createPage = `
   import { useRouter } from 'next/router'
 import React from "react";

--- a/commands/generate/pages/pageTypeTailwindcssPages/generateCreate.ts
+++ b/commands/generate/pages/pageTypeTailwindcssPages/generateCreate.ts
@@ -1,6 +1,6 @@
 // Generate the create tailwindcss page.
-export const generateCreate = (modelName: string, upperCaseFirstLetterModelName: string, finalJsonBodyItems: string, finalFormFieldItems: string) => {
-
+export const generateCreate = (modelName: string, idType: string, upperCaseFirstLetterModelName: string, finalJsonBodyItems: string, finalFormFieldItems: string) => {
+  
   const createPage = `
   import { useRouter } from 'next/router'
 import React from "react";

--- a/commands/generate/pages/pageTypeTailwindcssPages/generateDynamic.js
+++ b/commands/generate/pages/pageTypeTailwindcssPages/generateDynamic.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.generateDynamic = void 0;
-const generateDynamic = (modelName, upperCaseFirstLetterModelName, finalSchemaItemsForDynamicPage) => {
+const generateDynamic = (modelName, idType, upperCaseFirstLetterModelName, finalSchemaItemsForDynamicPage) => {
     const dynamicPage = `
   import Link from 'next/link'
 import { useRouter } from "next/router";
@@ -32,7 +32,7 @@ export default function ${upperCaseFirstLetterModelName}Details(props) {
                   >
                     Back
                   </button>
-                  <Link href={"/${modelName}s/edit${upperCaseFirstLetterModelName}s/" + ${modelName}._id}>
+                  <Link href={"/${modelName}s/edit${upperCaseFirstLetterModelName}s/" + ${modelName}.${idType}}>
                     <a className="m-1 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-xl font-light rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" >
                       Edit
                     </a>

--- a/commands/generate/pages/pageTypeTailwindcssPages/generateDynamic.ts
+++ b/commands/generate/pages/pageTypeTailwindcssPages/generateDynamic.ts
@@ -1,5 +1,5 @@
 // Generate the dynamic tailwindcss page.
-export const generateDynamic = (modelName: string, upperCaseFirstLetterModelName: string, finalSchemaItemsForDynamicPage: string) => {
+export const generateDynamic = (modelName: string, idType: string, upperCaseFirstLetterModelName: string, finalSchemaItemsForDynamicPage: string) => {
 
   const dynamicPage = `
   import Link from 'next/link'
@@ -31,7 +31,7 @@ export default function ${upperCaseFirstLetterModelName}Details(props) {
                   >
                     Back
                   </button>
-                  <Link href={"/${modelName}s/edit${upperCaseFirstLetterModelName}s/" + ${modelName}._id}>
+                  <Link href={"/${modelName}s/edit${upperCaseFirstLetterModelName}s/" + ${modelName}.${idType}}>
                     <a className="m-1 inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-xl font-light rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" >
                       Edit
                     </a>

--- a/commands/generate/pages/pageTypeTailwindcssPages/generateEdit.js
+++ b/commands/generate/pages/pageTypeTailwindcssPages/generateEdit.js
@@ -1,7 +1,7 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.generateEdit = void 0;
-const generateEdit = (modelName, upperCaseFirstLetterModelName, finalJsonBodyItems, finalEditFormFieldItems) => {
+const generateEdit = (modelName, idType, upperCaseFirstLetterModelName, finalJsonBodyItems, finalEditFormFieldItems) => {
     const editPage = `
   import { useRouter } from "next/router";
 

--- a/commands/generate/pages/pageTypeTailwindcssPages/generateEdit.ts
+++ b/commands/generate/pages/pageTypeTailwindcssPages/generateEdit.ts
@@ -1,5 +1,5 @@
 // Generate the edit tailwindcss page.
-export const generateEdit = (modelName: string, upperCaseFirstLetterModelName: string, finalJsonBodyItems: string, finalEditFormFieldItems: string) => {
+export const generateEdit = (modelName: string, idType: string, upperCaseFirstLetterModelName: string, finalJsonBodyItems: string, finalEditFormFieldItems: string) => {
 
   const editPage = `
   import { useRouter } from "next/router";

--- a/commands/generate/pages/pageTypeTailwindcssPages/generateIndex.js
+++ b/commands/generate/pages/pageTypeTailwindcssPages/generateIndex.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.generateIndex = void 0;
 const pagesUtils_1 = require("./pagesUtils");
-const generateIndex = (modelName, finalSchemaItemsForIndex) => {
+const generateIndex = (modelName, idType, finalSchemaItemsForIndex) => {
     let upperCaseFirstLetterModelName = (0, pagesUtils_1.getUpperCaseFirstLetter)(modelName);
     const tailwindcssIndex = `
     import Link from 'next/link'
@@ -31,11 +31,11 @@ const generateIndex = (modelName, finalSchemaItemsForIndex) => {
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 {props.${modelName}s.map((${modelName}) => (
                   <div
-                    key={${modelName}._id}
+                    key={${modelName}.${idType}}
                     className="relative rounded-lg border border-gray-300 bg-white px-6 py-5 shadow-sm flex items-center space-x-3 hover:border-gray-400 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-indigo-500"
                   >
                     <div className="flex-1 min-w-0">
-                      <a href={"/${modelName}s/" + ${modelName}._id} className="focus:outline-none">
+                      <a href={"/${modelName}s/" + ${modelName}.${idType}} className="focus:outline-none">
                         <span className="absolute inset-0" aria-hidden="true" />
                         ${finalSchemaItemsForIndex}
                       </a>

--- a/commands/generate/pages/pageTypeTailwindcssPages/generateIndex.ts
+++ b/commands/generate/pages/pageTypeTailwindcssPages/generateIndex.ts
@@ -1,7 +1,7 @@
 import { getUpperCaseFirstLetter } from "./pagesUtils"
 
 // Generate the index tailwindcss page.
-export const generateIndex = (modelName: string, finalSchemaItemsForIndex: string) => {
+export const generateIndex = (modelName: string, idType: string, finalSchemaItemsForIndex: string) => {
 
     let upperCaseFirstLetterModelName = getUpperCaseFirstLetter(modelName)
 
@@ -33,11 +33,11 @@ export const generateIndex = (modelName: string, finalSchemaItemsForIndex: strin
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                 {props.${modelName}s.map((${modelName}) => (
                   <div
-                    key={${modelName}._id}
+                    key={${modelName}.${idType}}
                     className="relative rounded-lg border border-gray-300 bg-white px-6 py-5 shadow-sm flex items-center space-x-3 hover:border-gray-400 focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-indigo-500"
                   >
                     <div className="flex-1 min-w-0">
-                      <a href={"/${modelName}s/" + ${modelName}._id} className="focus:outline-none">
+                      <a href={"/${modelName}s/" + ${modelName}.${idType}} className="focus:outline-none">
                         <span className="absolute inset-0" aria-hidden="true" />
                         ${finalSchemaItemsForIndex}
                       </a>

--- a/commands/generate/pages/pageTypeTailwindcssPages/tailwindcssPageController.js
+++ b/commands/generate/pages/pageTypeTailwindcssPages/tailwindcssPageController.js
@@ -11,6 +11,7 @@ const generateEdit_1 = require("./generateEdit");
 const tailwindcssPageController = async (userInput) => {
     const modelName = userInput[2];
     let configData = await (0, utils_1.readNextConfig)();
+    let idType = (0, utils_1.getIdType)();
     const modelItems = userInput.slice(3);
     if (!modelName) {
         return `no modelName recieved`;
@@ -20,10 +21,10 @@ const tailwindcssPageController = async (userInput) => {
     }
     const upperCaseFirstLetterModelName = modelName.charAt(0).toUpperCase() + modelName.slice(1);
     const finalDynamicData = (0, getDynamicTailwindcssData_1.getDynamicTailwindcssData)(modelName, modelItems);
-    const indexPage = (0, generateIndex_1.generateIndex)(modelName, finalDynamicData.finalSchemaItemsForIndex);
-    const dynamicPage = (0, generateDynamic_1.generateDynamic)(modelName, upperCaseFirstLetterModelName, finalDynamicData.finalSchemaItemsForDynamicPage);
-    const createPage = (0, generateCreate_1.generateCreate)(modelName, upperCaseFirstLetterModelName, finalDynamicData.finalJsonBodyItems, finalDynamicData.finalFormFieldItems);
-    const editPage = (0, generateEdit_1.generateEdit)(modelName, upperCaseFirstLetterModelName, finalDynamicData.finalJsonBodyItems, finalDynamicData.finalEditFormFieldItems);
+    const indexPage = (0, generateIndex_1.generateIndex)(modelName, idType, finalDynamicData.finalSchemaItemsForIndex);
+    const dynamicPage = (0, generateDynamic_1.generateDynamic)(modelName, idType, upperCaseFirstLetterModelName, finalDynamicData.finalSchemaItemsForDynamicPage);
+    const createPage = (0, generateCreate_1.generateCreate)(modelName, idType, upperCaseFirstLetterModelName, finalDynamicData.finalJsonBodyItems, finalDynamicData.finalFormFieldItems);
+    const editPage = (0, generateEdit_1.generateEdit)(modelName, idType, upperCaseFirstLetterModelName, finalDynamicData.finalJsonBodyItems, finalDynamicData.finalEditFormFieldItems);
     if (!(0, fs_1.existsSync)(`${configData.projectRootPath}pages`)) {
         (0, utils_1.createDirectory)(`${configData.projectRootPath}pages`);
     }

--- a/commands/generate/pages/pageTypeTailwindcssPages/tailwindcssPageController.ts
+++ b/commands/generate/pages/pageTypeTailwindcssPages/tailwindcssPageController.ts
@@ -1,4 +1,4 @@
-import { createDirectory, createFile, readNextConfig } from "../../../../utils";
+import { createDirectory, createFile, getIdType, readNextConfig } from "../../../../utils";
 import { existsSync } from "fs";
 import { getDynamicTailwindcssData } from "./getDynamicTailwindcssData"
 import { generateIndex } from "./generateIndex"
@@ -11,6 +11,7 @@ export const tailwindcssPageController = async (userInput: string[]) => {
   const modelName = userInput[2];
 
   let configData = await readNextConfig()
+  let idType = getIdType()
 
   const modelItems = userInput.slice(3);
 
@@ -29,16 +30,16 @@ export const tailwindcssPageController = async (userInput: string[]) => {
   const finalDynamicData = getDynamicTailwindcssData(modelName, modelItems)
 
   // generates the index page
-  const indexPage = generateIndex(modelName, finalDynamicData.finalSchemaItemsForIndex)
+  const indexPage = generateIndex(modelName, idType, finalDynamicData.finalSchemaItemsForIndex)
 
   //  generates the dynamic page
-  const dynamicPage = generateDynamic(modelName, upperCaseFirstLetterModelName, finalDynamicData.finalSchemaItemsForDynamicPage)
+  const dynamicPage = generateDynamic(modelName, idType, upperCaseFirstLetterModelName, finalDynamicData.finalSchemaItemsForDynamicPage)
 
   // generates the create page
-  const createPage = generateCreate(modelName, upperCaseFirstLetterModelName, finalDynamicData.finalJsonBodyItems, finalDynamicData.finalFormFieldItems)
+  const createPage = generateCreate(modelName, idType, upperCaseFirstLetterModelName, finalDynamicData.finalJsonBodyItems, finalDynamicData.finalFormFieldItems)
 
   // generates the edit page
-  const editPage = generateEdit(modelName, upperCaseFirstLetterModelName, finalDynamicData.finalJsonBodyItems, finalDynamicData.finalEditFormFieldItems)
+  const editPage = generateEdit(modelName, idType, upperCaseFirstLetterModelName, finalDynamicData.finalJsonBodyItems, finalDynamicData.finalEditFormFieldItems)
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,18 @@
 {
   "name": "next-generator",
-  "version": "1.1.12",
+  "version": "2.1.3-alpha",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-generator",
-      "version": "1.1.12",
+      "version": "2.1.3-alpha",
       "license": "ISC",
       "dependencies": {
         "typescript": "^4.4.3"
+      },
+      "bin": {
+        "nextGen": "bin/index.js"
       },
       "devDependencies": {
         "jest": "^27.0.4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-generator",
-  "version": "2.1.3-alpha",
+  "version": "2.2.0-alpha",
   "description": "Your Next.js route, model, and page generator.",
   "main": "./bin/index.js",
   "bin": {

--- a/utils.js
+++ b/utils.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.readNextConfig = exports.createFile = exports.createDirectory = void 0;
+exports.readNextConfig = exports.getIdType = exports.createFile = exports.createDirectory = void 0;
 const fs_1 = __importDefault(require("fs"));
 const nextGeneratorConfig_1 = require("./nextGeneratorConfig");
 const createDirectory = (directoryPath) => {
@@ -28,6 +28,21 @@ const createFile = (filePath, fileContent) => {
     return `file created`;
 };
 exports.createFile = createFile;
+const getIdType = () => {
+    const configData = (0, exports.readNextConfig)();
+    switch (configData.database) {
+        case "postgresql":
+            return "id";
+            break;
+        case "mongodb":
+            return "_id";
+            break;
+        default:
+            return "_id";
+            break;
+    }
+};
+exports.getIdType = getIdType;
 const readNextConfig = () => {
     let configData;
     let path = `nextGenConfig.json`;

--- a/utils.ts
+++ b/utils.ts
@@ -28,7 +28,7 @@ export const createFile = (filePath: string, fileContent: string) => {
 };
 
 // This reads the nextGenConfig file,
-//  and returns _id for mongodb and id for postges
+// returns _id for mongodb and id for postges
 export const getIdType = () => {
   const configData = readNextConfig()
 

--- a/utils.ts
+++ b/utils.ts
@@ -27,6 +27,25 @@ export const createFile = (filePath: string, fileContent: string) => {
   return `file created`;
 };
 
+// This reads the nextGenConfig file,
+//  and returns _id for mongodb and id for postges
+export const getIdType = () => {
+  const configData = readNextConfig()
+
+  switch (configData.database) {
+    case "postgresql":
+      return "id"
+      break;
+    case "mongodb":
+      return "_id"
+      break;
+    default:
+      return "_id"
+      break;
+  }
+
+}
+
 // accepted databases & styles located in next-generator-config.ts
 // example of next config format given in nextGenConfigExample.json
 export const readNextConfig = () => {


### PR DESCRIPTION
## Next Generator pull request

**Summary of changes made:**
I made a utility function that checks the nextGenConfig, and depending on the database, the idType for the routes is returned as "_id" for mongodb or "id" for postgresql.

**Summary of testing method for these changes:**
Both database types (mongodb and postgresql) were tested successfully.

**Extra context or other helpful information to help reviewer:**
- This corrects issue #24 
- and finishes #22 
